### PR TITLE
 :children_crossing: let opinions to be undefined when changing pagination index so the table will show skeleton

### DIFF
--- a/app/(saas)/kol/[kolName]/page.tsx
+++ b/app/(saas)/kol/[kolName]/page.tsx
@@ -314,7 +314,7 @@ export default function KOLProfile() {
             className={`py-1 px-3 rounded-2xl text-[0.75rem] font-[600] text-center
               bg-[#fef3c7] text-[#92400e] dark:bg-[#92400e] dark:text-[#fef3c7]`}
           >
-            {t("tabs.opinionHistory.tab3le.accuracy.partial")}
+            {t("tabs.opinionHistory.table.accuracy.partial")}
           </span>
         )
     }

--- a/app/(saas)/kol/[kolName]/page.tsx
+++ b/app/(saas)/kol/[kolName]/page.tsx
@@ -645,7 +645,10 @@ export default function KOLProfile() {
                   <PaginationContent>
                     <PaginationItem>
                       <PaginationFirst
-                        onClick={() => setPaginationIndex(1)}
+                        onClick={() => {
+                          setPaginationIndex(1);
+                          setKOLOpinions(undefined);
+                        }}
                         className={`cursor-pointer`}
                       />
                     </PaginationItem>
@@ -656,7 +659,10 @@ export default function KOLProfile() {
                       ).map((num) => (
                         <PaginationItem key={num}>
                           <PaginationLink
-                            onClick={() => setPaginationIndex(num)}
+                            onClick={() => {
+                              setPaginationIndex(num);
+                              setKOLOpinions(undefined);
+                            }}
                             className={`cursor-pointer`}
                             isActive={num === paginationIndex}
                           >
@@ -674,9 +680,10 @@ export default function KOLProfile() {
                         ).map((num) => (
                           <PaginationItem key={num}>
                             <PaginationLink
-                              onClick={() =>
-                                setPaginationIndex(paginationIndex + num)
-                              }
+                              onClick={() => {
+                                setPaginationIndex(paginationIndex + num);
+                                setKOLOpinions(undefined);
+                              }}
                               className={`cursor-pointer`}
                               isActive={num === 0}
                             >
@@ -691,7 +698,10 @@ export default function KOLProfile() {
                     )}
                     <PaginationItem>
                       <PaginationLast
-                        onClick={() => setPaginationIndex(paginationTotalPage)}
+                        onClick={() => {
+                          setPaginationIndex(paginationTotalPage);
+                          setKOLOpinions(undefined);
+                        }}
                         className={`cursor-pointer`}
                       />
                     </PaginationItem>

--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,7 @@
             "token": "Token",
             "opinion": "Opinion",
             "score": "Score",
-            "date": "Date/Time",
+            "date": "Mention At",
             "source": "Source",
             "24Outcome": "24h",
             "72Outcome": "72h",


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

The motivation of this PR is for users' experience when browsing opinion table in `KOLProfile` page. When we change pagination index of table, the table's data will change suddenly. That's an awful experience, so I set the opinions to `undefined` when we change pagination index so that the table will only show skeletons.

### 🌴 PR Type

<!-- Please check the PR type -->

+ [x] ✨ Feature
+ [ ] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 📸 Screenshots (if UI changes)

### 📹 Demo Video (if new feature)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.