### PR TITLE
:ambulance: hotfix(error-handle): fix the problem that `kLineRes.data` can be `null` and calling `sort` method on it will cause error

### DIFF
--- a/app/(saas)/kol/[kolName]/page.tsx
+++ b/app/(saas)/kol/[kolName]/page.tsx
@@ -147,13 +147,14 @@ export default function KOLProfile() {
               return {
                 ...opinion,
                 kLineData:
-                  kLineRes.data.sort(
+                  kLineRes?.data?.sort(
                     (a, b) => parseInt(a.timestamp) - parseInt(b.timestamp)
                   ) || undefined,
               };
 
               // Notice `TokenKLineResponse.data` responses as descending order in
-              // `timestamp`.
+              // `timestamp`. And sometimes the token is not in our database (okx), the
+              // kLineRes.data will be `null`, then it will cause a error.
             } catch (err) {
               toast.error(`${err}`);
               return {


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR hotfixes the issue #35 , when `kLineRes.data` is null, the `kLineData` property will return `undefined`

### 🌴 PR Type

<!-- Please check the PR type -->

+ [ ] ✨ Feature
+ [ ] 🐛 Bugfix
+ [x] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 📸 Screenshots (if UI changes)

### 📹 Demo Video (if new feature)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.