### PR TITLE
:bug: fix(hook): remove `useCallback` function cache hook on `paginationIndex`-related function

### DIFF
--- a/app/(saas)/kol/[kolName]/page.tsx
+++ b/app/(saas)/kol/[kolName]/page.tsx
@@ -119,7 +119,8 @@ export default function KOLProfile() {
     // and only set variables when it's not `null`.
   }, [kolName, t]);
 
-  const fetchKOLOpinions = useCallback(async () => {
+  /* This function cannot use `useCallback` because the fetch url is related to `paginationIndex` */
+  const fetchKOLOpinions = async () => {
     try {
       const res: KOLOpinionResponse = await fetch(
         `/api/kol/${kolName}/opinion?pn=${paginationIndex}&ps=10`
@@ -174,7 +175,7 @@ export default function KOLProfile() {
       });
       console.error(err instanceof Error ? err.message : err);
     }
-  }, [kolName, t]);
+  };
 
   const fetchKOLStatus = useCallback(async () => {
     try {
@@ -238,6 +239,7 @@ export default function KOLProfile() {
 
   useEffect(() => {
     fetchKOLOpinions();
+    console.log(paginationIndex)
   }, [paginationIndex]);
 
   /** This component is only used for table in `KOLProfile` page. */


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR is originally planed as from `v0-fix/null-kline-data`. It removes the `useCallback` hook on function `fetchKOLOpinions` because this function is different when `paginationIndex` is different 

### 🌴 PR Type

<!-- Please check the PR type -->

+ [ ] ✨ Feature
+ [x] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 📸 Screenshots (if UI changes)

### 📹 Demo Video (if new feature)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.